### PR TITLE
Support interfaces with name other than eth0

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ service rsyslog start
 sysctl -w net.ipv4.ip_forward=1
 
 # configure firewall
-iptables -t nat -A POSTROUTING -s 10.99.99.0/24 -o eth0 -j MASQUERADE
+iptables -t nat -A POSTROUTING -s 10.99.99.0/24 ! -d 10.99.99.0/24 -j MASQUERADE
 iptables -A FORWARD -s 10.99.99.0/24 -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -j TCPMSS --set-mss 1356
 
 exec "$@"


### PR DESCRIPTION
This fixes the iptables rule which only applies SNAT
if traffic gets out from eth0. In my case I also wanted
to apply SNAT for traffic going to internal bridge interface.
