### PR TITLE
Fix issue with using ubuntu:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:16.04
 MAINTAINER Przemek Szalko <przemek@mobtitude.com>
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# start logging
-service rsyslog start
-
 # enable IP forwarding
 sysctl -w net.ipv4.ip_forward=1
 


### PR DESCRIPTION
rsyslog service was no longer existent
when pulling from ubuntu:latest. Also instead
of relying on ubuntu:latest it's better
to rely on a specific version, such that our
image won't break on a new release.
