### PR TITLE
support for multiple clients

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,9 +8,9 @@ sysctl -w net.ipv4.ip_forward=1
 # configure firewall
 iptables -t nat -A POSTROUTING -s 10.99.99.0/24 ! -d 10.99.99.0/24 -j MASQUERADE
 iptables -A FORWARD -s 10.99.99.0/24 -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -j TCPMSS --set-mss 1356
-iptables -A INPUT -i ppp0 -j ACCEPT
-iptables -A OUTPUT -o ppp0 -j ACCEPT
-iptables -A FORWARD -i ppp0 -j ACCEPT
-iptables -A FORWARD -o ppp0 -j ACCEPT
+iptables -A INPUT -i ppp+ -j ACCEPT
+iptables -A OUTPUT -o ppp+ -j ACCEPT
+iptables -A FORWARD -i ppp+ -j ACCEPT
+iptables -A FORWARD -o ppp+ -j ACCEPT
 
 exec "$@"


### PR DESCRIPTION
for each client a new network interface is created. using + instead of 0 applies these rules to all clients instead of just the first client who connects.

Based on deba12's comment in issue #16 