### PR TITLE
增加MTU大小设置，解决部分客户端连接后不能正常协商MTU长度问题

### DIFF
--- a/etc/ppp/pptpd-options
+++ b/etc/ppp/pptpd-options
@@ -21,3 +21,4 @@ nobsdcomp
 novj
 novjccomp
 nologfd
+mtu 1400


### PR DESCRIPTION
Increase the MTU size setting to solve the problem that the MTU length cannot be negotiated normally after some clients connect